### PR TITLE
BROKEN Update MoinMoin 2.6.11 for TKL18

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,14 @@
+turnkey-moinmoin-18 (1) turnkey; urgency=low
+
+  * Already at latest upstream version of MoinMoin: 2.6.11 (project seems stale from 2014).
+
+  * Re-build on TurnKey Linux 18 (Debian 12 'bookworm')
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Daniele Lolli <github@uncledan.it>  Tue, 3 Aug 2023 19:00:00 +0200
+
 turnkey-moinmoin-16.1 (1) turnkey; urgency=low
 
   * Rebuilt against latest Buster

--- a/plan/main
+++ b/plan/main
@@ -2,7 +2,7 @@
 
 apache2
 webmin-apache
-libapache2-mod-wsgi
+libapache2-mod-wsgi-py3
 python-flup
 
 python-moinmoin

--- a/plan/main
+++ b/plan/main
@@ -2,7 +2,7 @@
 
 apache2
 webmin-apache
-libapache2-mod-wsgi-py3
+libapache2-mod-wsgi
 python-flup
 
 python-moinmoin


### PR DESCRIPTION
Broken dependencies libapache2-mod-wsgi, python-flup, python-moinmoin Too old software?